### PR TITLE
启动MPV库的硬解模式可以显著降低视频壁纸的资源占用。

### DIFF
--- a/LiveWallpaperEngineAPI/Forms/VideoControl.cs
+++ b/LiveWallpaperEngineAPI/Forms/VideoControl.cs
@@ -60,7 +60,9 @@ namespace LiveWallpaperEngineAPI.Forms
                 return;
 
             _lastPath = path;
-
+            // 设置解码模式为自动，如果条件允许，MPV会启动硬件解码
+            _player?.API.SetPropertyString("hwdec", "auto");
+            //_player.API.SetProperty("hwdec",Encoding.Default.GetBytes("auto"));
             _player?.Pause();
             _player?.Load(path);
             _player?.Resume();


### PR DESCRIPTION
[参考文档](https://mpv.io/manual/stable/#gpu-renderer-options)

## 文档摘抄
> --hwdec=\<api\>
Specify the hardware video decoding API that should be used if possible. Whether hardware decoding is actually done depends on the video codec. If hardware decoding is not possible, mpv will fall back on software decoding.
Hardware decoding is not enabled by default, because it is typically an additional source of errors. It is worth using only if your CPU is too slow to decode a specific video.

> \<api\> can be one of the following:auto

> auto tries to automatically enable hardware decoding using the first available method. This still depends what VO you are using. For example, if you are not using --vo=gpu or --vo=vdpau, vdpau decoding will never be enabled. Also note that if the first found method doesn't actually work, it will always fall back to software decoding, instead of trying the next method (might matter on some Linux systems).

## 实际效果
CPU：Intel Core i5-7300HQ
OS：Windows10 1909 X64
所用视频：
+ 长度：4分40秒左右
+ 大小：412MB
+ FPS：60

启动硬解前CPU占用20%~35%。启动硬解后基本维持在10%以下。